### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -35,6 +35,7 @@ jobs:
           ls ~/.cargo/bin
           echo $(readlink --canonicalize ~/.cargo/bin)
           echo $PATH
+          echo "${{ env.PATH }}"
       - uses: cloudflare/wrangler-action@1.3.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -30,6 +30,9 @@ jobs:
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: worker-build
       - run: |
           echo $(readlink --canonicalize ~/.cargo/bin) >> $GITHUB_PATH
           npm i @cloudflare/wrangler

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ci
 
 jobs:
   deploy:
@@ -30,6 +31,9 @@ jobs:
         with:
           command: install
           args: worker-build
+      - run: |
+          ls ~/.cargo/bin
+          echo $(readlink --canonicalize ~/.cargo/bin)
       - uses: cloudflare/wrangler-action@1.3.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -31,15 +31,15 @@ jobs:
         with:
           command: install
           args: worker-build
-      - name: Add cargo to path
-        run: |
+      - run: |
           echo $(readlink --canonicalize ~/.cargo/bin) >> $GITHUB_PATH
       - run: |
           echo $PATH
           echo "${{ env.PATH }}"
-      - uses: cloudflare/wrangler-action@1.3.0
-        with:
-          apiToken: ${{ secrets.CF_API_TOKEN }}
+      - run: |
+          npm i @cloudflare/wrangler
+          npx wrangler publish
         env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -33,10 +33,6 @@ jobs:
           args: worker-build
       - run: |
           echo $(readlink --canonicalize ~/.cargo/bin) >> $GITHUB_PATH
-      - run: |
-          echo $PATH
-          echo "${{ env.PATH }}"
-      - run: |
           npm i @cloudflare/wrangler
           npx wrangler publish
         env:

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -20,7 +20,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-check
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -20,10 +20,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-cargo-
+            cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-
+            cargo-${{ runner.os }}-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -30,10 +30,6 @@ jobs:
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: worker-build
       - run: |
           echo $(readlink --canonicalize ~/.cargo/bin) >> $GITHUB_PATH
           npm i @cloudflare/wrangler

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -30,11 +30,9 @@ jobs:
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: worker-build
       - run: |
           echo $(readlink --canonicalize ~/.cargo/bin) >> $GITHUB_PATH
+          cargo install worker-build || true
           npm i @cloudflare/wrangler
           npx wrangler publish
         env:

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -31,9 +31,10 @@ jobs:
         with:
           command: install
           args: worker-build
+      - name: Add cargo to path
+        run: |
+          echo $(readlink --canonicalize ~/.cargo/bin) >> $GITHUB_PATH
       - run: |
-          ls ~/.cargo/bin
-          echo $(readlink --canonicalize ~/.cargo/bin)
           echo $PATH
           echo "${{ env.PATH }}"
       - uses: cloudflare/wrangler-action@1.3.0

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -30,9 +30,12 @@ jobs:
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown
-      - run: |
-          echo $(readlink --canonicalize ~/.cargo/bin) >> $GITHUB_PATH
-          cargo install worker-build || true
+      - name: Add Cargo/Rust to PATH
+        run: echo $(readlink --canonicalize ~/.cargo/bin) >> $GITHUB_PATH
+      - name: Install worker-build if not exists
+        run: cargo install worker-build || true
+      - name: Publish to Cloudflare Workers
+        run: |
           npm i @cloudflare/wrangler
           npx wrangler publish
         env:

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ci
 
 jobs:
   deploy:

--- a/.github/workflows/wrangler.yml
+++ b/.github/workflows/wrangler.yml
@@ -34,6 +34,7 @@ jobs:
       - run: |
           ls ~/.cargo/bin
           echo $(readlink --canonicalize ~/.cargo/bin)
+          echo $PATH
       - uses: cloudflare/wrangler-action@1.3.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,7 +21,7 @@ binding = "LINKS"
 id = "2d62bc3067404ade9c9a71d9bc6d7c96"
 
 [build]
-command = "cargo install -q worker-build && worker-build --release" # required
+command = "worker-build --release" # required
 
 [build.upload]
 dir    = "build/worker"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,7 +21,7 @@ binding = "LINKS"
 id = "2d62bc3067404ade9c9a71d9bc6d7c96"
 
 [build]
-command = "worker-build --release" # required
+command = "cargo install -q worker-build && worker-build --release" # required
 
 [build.upload]
 dir    = "build/worker"


### PR DESCRIPTION
Fixes consistently failing CI builds by installing wrangler from NPM instead of using the official Cloudflare wrangler action. We cannot use the official wrangler action as it does not work with Rust workers (cloudflare/wrangler-action#61).